### PR TITLE
Tweak .clang-format YAML output

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,11 @@ def make_initial_configs(args):
 
 
 def present_config(config, args, exiting):
-    config_buffer = dump(config)
+    config_buffer = dump(
+        config,
+        default_flow_style=False,
+        explicit_start=True,
+        explicit_end=True)
     if args.root:
         # If output is file, always write out results
         # because the same copy can be updated with latest and greatest.


### PR DESCRIPTION
Add keyword arguments to yaml.dump to use block style and explicit start
and end indicators, like the .clang-format files produced by the
clang-format tool do.

Fixes #18.